### PR TITLE
2025.1.0: Updated docker run command and update ReadMe.md

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -80,3 +80,166 @@ Sample to create Qlik-Replicate base image to run in OpenShift
 ---
 ### _2024.5.0-144.dockerfile:_
   - This has not been used yet. It will need a core base image created. Use _**2023.11.0-720-core.Dockerfile**_ as an example.
+---
+
+## Testing Images:
+
+### _qlikr:8_:
+```shell
+# Run docker image:
+docker run --rm --platform linux/amd64 -it docker.artifacts/qlikr:8
+
+# Image command:
+ls
+```
+```text
+# Output:
+bin  boot  dev  etc  home  lib  lib64  lost+found  media  mnt  opt  proc  root  run  sbin  srv  sys  tmp  usr  var
+```
+---
+### _qlikr:8-core_:
+```shell
+# Run docker image:
+docker run --rm --platform linux/amd64 -it docker.artifacts/qlikr:8-core
+```
+```text
+# Output:
+Image Versions
+-------------------------------------------------------------------------------------------------
+OS................: CentOS Linux 8
+Python3...........: 3.6.8
+-------------------------------------------------------------------------------------------------
+SystemD...........: systemd 239 (239-51.el8_5.2)
+unixODBC..........: 2.3.7
+SQL-ODBC..........: ODBC for PostgreSQL ODBC for MySQL Free Sybase & MS SQL Driver ODBC for MariaDB Microsoft ODBC Driver 18 for SQL Server
+Curl..............: 7.61.1 - 2018-09-05
+Wget..............: GNU Wget 1.19.5 built on linux-gnu.
+JQ................: jq-1.5
+Bash..............: 4.4.20 (redhat-x86_64)
+-------------------------------------------------------------------------------------------------
+TimeZone..........: America/Chicago
+DateTime..........: Sun Jan 12 10:19:25 CST 2025
+-------------------------------------------------------------------------------------------------
+```
+```shell
+# Image command:
+ls
+```
+```text
+# Output:
+total 60
+lrwxrwxrwx   1 root root    7 Jun 22  2021 bin -> usr/bin
+dr-xr-xr-x   4 root root 4096 Jan 11 09:37 boot
+-rw-r--r--   1 root root  323 Jan 12 10:19 currentVersions.json
+drwxr-xr-x   5 root root  360 Jan 12 10:19 dev
+-rwxr-xr-x   1 root root    0 Jan 12 10:19 .dockerenv
+drwxr-xr-x   1 root root 4096 Jan 12 10:19 etc
+drwxr-xr-x   2 root root 4096 Nov  3  2020 home
+lrwxrwxrwx   1 root root    7 Jun 22  2021 lib -> usr/lib
+lrwxrwxrwx   1 root root    9 Jun 22  2021 lib64 -> usr/lib64
+drwx------   2 root root 4096 Sep 15  2021 lost+found
+drwxr-xr-x   2 root root 4096 Nov  3  2020 media
+drwxr-xr-x   2 root root 4096 Nov  3  2020 mnt
+drwxr-xr-x   1 root root 4096 Jan 11 09:38 opt
+dr-xr-xr-x 287 root root    0 Jan 12 10:19 proc
+dr-xr-x---   1 root root 4096 Jun 22  2021 root
+drwxr-xr-x   1 root root 4096 Jan 11 09:37 run
+lrwxrwxrwx   1 root root    8 Jun 22  2021 sbin -> usr/sbin
+drwxr-xr-x   2 root root 4096 Nov  3  2020 srv
+dr-xr-xr-x  11 root root    0 Jan 12 10:19 sys
+drwxrwxrwt   1 root root 4096 Jan 11 09:38 tmp
+drwxr-xr-x   1 root root 4096 Jan 11 09:37 usr
+drwxr-xr-x   1 root root 4096 Jan 11 09:37 var
+-rwxr-xr-x   1 root root 3715 Jan  8 19:51 versionCheck.sh
+```
+---
+### _qlikr:2023.11.0-720-core_:
+```shell
+# Run docker image:
+docker run --rm --platform linux/amd64 -it docker.artifacts/qlikr:2023.11.0-720-core
+```
+```text
+Image Versions
+-------------------------------------------------------------------------------------------------
+OS................: CentOS Linux 8
+Python3...........: 3.6.8
+-------------------------------------------------------------------------------------------------
+SystemD...........: systemd 239 (239-51.el8_5.2)
+unixODBC..........: 2.3.7
+SQL-ODBC..........: ODBC for PostgreSQL ODBC for MySQL Free Sybase & MS SQL Driver ODBC for MariaDB Microsoft ODBC Driver 18 for SQL Server
+Curl..............: 7.61.1 - 2018-09-05
+Wget..............: GNU Wget 1.19.5 built on linux-gnu.
+JQ................: jq-1.5
+Bash..............: 4.4.20 (redhat-x86_64)
+-------------------------------------------------------------------------------------------------
+TimeZone..........: America/Chicago
+DateTime..........: Sun Jan 12 10:19:25 CST 2025
+-------------------------------------------------------------------------------------------------
+```
+```shell
+# Image command:
+ls
+```
+```shell
+# Output:
+total 60
+lrwxrwxrwx   1 root root    7 Jun 22  2021 bin -> usr/bin
+dr-xr-xr-x   4 root root 4096 Jan 11 09:37 boot
+-rw-r--r--   1 root root  323 Jan 12 10:19 currentVersions.json
+drwxr-xr-x   5 root root  360 Jan 12 10:19 dev
+-rwxr-xr-x   1 root root    0 Jan 12 10:19 .dockerenv
+drwxr-xr-x   1 root root 4096 Jan 12 10:19 etc
+drwxr-xr-x   2 root root 4096 Nov  3  2020 home
+lrwxrwxrwx   1 root root    7 Jun 22  2021 lib -> usr/lib
+lrwxrwxrwx   1 root root    9 Jun 22  2021 lib64 -> usr/lib64
+drwx------   2 root root 4096 Sep 15  2021 lost+found
+drwxr-xr-x   2 root root 4096 Nov  3  2020 media
+drwxr-xr-x   2 root root 4096 Nov  3  2020 mnt
+drwxr-xr-x   1 root root 4096 Jan 11 09:38 opt
+dr-xr-xr-x 287 root root    0 Jan 12 10:19 proc
+dr-xr-x---   1 root root 4096 Jun 22  2021 root
+drwxr-xr-x   1 root root 4096 Jan 11 09:37 run
+lrwxrwxrwx   1 root root    8 Jun 22  2021 sbin -> usr/sbin
+drwxr-xr-x   2 root root 4096 Nov  3  2020 srv
+dr-xr-xr-x  11 root root    0 Jan 12 10:19 sys
+drwxrwxrwt   1 root root 4096 Jan 11 09:38 tmp
+drwxr-xr-x   1 root root 4096 Jan 11 09:37 usr
+drwxr-xr-x   1 root root 4096 Jan 11 09:37 var
+-rwxr-xr-x   1 root root 3715 Jan  8 19:51 versionCheck.sh
+```
+```shell
+# Image command:
+ls /opt/attunity/replicate/bin
+```
+```text
+# Output:
+total 75696
+-rwxrwxr-x 1 attunity attunity 68834963 Aug 15 11:54 arepbq
+-rwxrwxr-x 1 attunity attunity   155360 Aug 15 11:54 arep_csv2prq
+-rwxrwxr-x 1 attunity attunity     2259 Aug 15 11:54 arep_login.sh
+-rwxrwxr-x 1 attunity attunity    13882 Aug 15 11:54 arep.sh
+-rwxrwxr-x 1 attunity attunity     1487 Aug 15 11:54 fix_permissions
+-rwxrwxr-x 1 attunity attunity  3955630 Aug 15 11:54 irpcd
+-rwxrwxr-x 1 attunity attunity  1239688 Aug 15 11:54 kdestroy
+-rwxrwxr-x 1 attunity attunity  1999928 Aug 15 11:54 kinit
+-rwxrwxr-x 1 attunity attunity  1253656 Aug 15 11:54 klist
+-rwxrwxr-x 1 attunity attunity     7226 Aug 15 11:54 nav_util
+-rwxrwxr-x 1 attunity attunity    15248 Aug 15 11:54 repctl
+-rwxrwxr-x 1 attunity attunity      789 Aug 15 11:54 repctl.cfg
+-rwxrwxr-x 1 attunity attunity      290 Aug 15 11:54 repctl.sh
+-rw-r--r-- 1 attunity attunity       36 Jan 11 09:38 site_arep_login.sh
+```
+---
+### _qlikr:2023.11.0-720_:
+```shell
+# Run docker image:
+./run_docker.sh 3552 docker.artifacts/qlikr:2023.11.0-720 AB1gL0ngPa33w0rd
+```
+```shell
+# Stop & Remove Container:
+docker stop qlikr && docker rm $_
+```
+#### Test Qlik Replicate:
+**_url:_** https://127.0.0.1:3552/attunityreplicate/  
+**_user:_** admin  
+**_pw:_** AB1gL0ngPa33w0rd  

--- a/run_docker.sh
+++ b/run_docker.sh
@@ -7,4 +7,5 @@ if [ -z $1 ] || [ -z $2 ] || [ -z $3 ]; then
   echo "Usage: run_docker.sh <Rest port> <Docker image> <Replicate password>"
   exit 1
 fi
-docker run -it --name qlikr --platform linux/amd64 -d -e ReplicateRestPort=$1 -e ReplicateAdminPassword=$3 -p $1:$1 --expose $1 --mount type=bind,source=/Users/rjd/PycharmGitHub/seQlikR/data,target=/replicate/qre-docker/data $2 --privileged
+#docker run --name qlikr -d -e ReplicateRestPort=$1 -e ReplicateAdminPassword=$3 -p $1:$1 --expose $1 --mount type=bind,source=/replicate/qre-docker/data,target=/replicate/qre-docker/data $2 --privileged
+docker run --name qlikr --platform linux/amd64 -d -e ReplicateRestPort=$1 -e ReplicateAdminPassword=$3 -p $1:$1 --expose $1  $2 --privileged


### PR DESCRIPTION
Adjusted the `docker run` command in `run_docker.sh` to include the `--platform` flag. Expanded the ReadMe.md with comprehensive testing instructions for various Qlikr images, including commands, outputs, and usage notes.